### PR TITLE
ET-707: Add vars to skip platform with module images and deploy to EKS

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -46,6 +46,7 @@ on:
         description: 'Whether to build QA images (platform with module)'
         required: true
         type: boolean
+        default: true
       namespace:
         description: 'Kubernetes namespace for the deployment'
         type: string

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -42,6 +42,13 @@ on:
         description: 'Whether this is a pre-release or release version'
         required: true
         type: string
+      build_qa_images:
+        description: 'Whether to build QA images (platform with module)'
+        required: true
+        type: boolean
+      namespace:
+        description: 'Kubernetes namespace for the deployment'
+        type: string
         
     secrets:
       GH_TOKEN:
@@ -121,6 +128,7 @@ jobs:
     secrets: inherit
     
   build-platform-build:
+    if: ${{ inputs.build_qa_images == 'true' }}
     needs: [setup, build-injectors]
     uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
@@ -138,6 +146,7 @@ jobs:
     secrets: inherit
     
   build-platform-components:
+    if: ${{ inputs.build_qa_images == 'true' }}
     needs: [setup, build-platform-build]
     strategy:
       matrix:
@@ -162,6 +171,7 @@ jobs:
     secrets: inherit
     
   build-qa-appserver:
+    if: ${{ inputs.build_qa_images == 'true' }}
     needs: [setup, build-platform-components]
     uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
@@ -176,4 +186,13 @@ jobs:
       is_release: ${{ inputs.is_release }}
       engineering_prefix: ${{ inputs.engineering_prefix }}
       releases_prefix: ${{ inputs.releases_prefix }}
+    secrets: inherit
+
+  redeploy-eks-pod:
+    if: ${{ inputs.namespace != '' && inputs.build_qa_images == 'true' }}
+    needs: [setup, build-platform-components]
+    uses: IQGeo/devops-engineering-ci-redeploy-eks-pod/.github/workflows/redeploy-eks-pod.yml@main
+    with:
+      module: ${{ fromJson(needs.setup.outputs.modules_array)[0] }}
+      namespace: ${{ inputs.namespace }}
     secrets: inherit


### PR DESCRIPTION
Added **build_qa_images** var to determine if we should skip building the platform with module QA images. We would pass this in from the main workflow file in each module repo so WFM, comms, etc. would pass in true so the QA images get built but the other modules like groups that can't be tested will call the same build-module workflow but pass in false for the QA images.

Also added a **namespace** var to pass in to the new redeploy-eks-pod workflow so that we know which pod to kill, either the pre-release or stable appserver. Initial logic I included here is that the namespace var is not required so that if the var is not passed in then PMG doesn't get touched. For deploying release images, we can use the is_release var to determine that the namespace should be whatever the stable namespace is for PMG. Do we need to introduce a new output from extract versions to denote this as a pre-release build or should we just redeploy the pre-release EKS container for all pre-release builds (alphas, betas, RCs, patches)?