### PR TITLE
Devops/et 705 hyphenate modules

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -198,11 +198,11 @@ jobs:
       releases_prefix: ${{ inputs.releases_prefix }}
     secrets: inherit
 
-  # redeploy-eks-pod:
-  #   if: ${{ inputs.namespace != '' && inputs.build_qa_images == true }}
-  #   needs: [setup, build-platform-components]
-  #   uses: IQGeo/devops-engineering-ci-redeploy-eks-pod/.github/workflows/redeploy-eks-pod.yml@main
-  #   with:
-  #     module: ${{ fromJson(needs.setup.outputs.modules_array)[0] }}
-  #     namespace: ${{ inputs.namespace }}
-  #   secrets: inherit
+  redeploy-eks-pod:
+    if: ${{ inputs.namespace != '' && inputs.build_qa_images == true }}
+    needs: [setup, build-platform-components]
+    uses: IQGeo/devops-engineering-ci-redeploy-eks-pod/.github/workflows/redeploy-eks-pod.yml@main
+    with:
+      module: ${{ fromJson(needs.setup.outputs.modules_array)[0] }}
+      namespace: ${{ inputs.namespace }}
+    secrets: inherit


### PR DESCRIPTION
Small PR to add a job to the build-module workflow that hyphenates the first item in the modules_array (the main module name) and use that downstream for the platform-with-module QA image builds.

Successful test run here: https://github.com/IQGeo/myworld-product-workflow-manager/actions/runs/17959674183/job/51079843463