### PR TITLE
Add step for redeploying EKS pod using pod_name from main workflow

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -49,6 +49,9 @@ on:
       namespace:
         description: 'Kubernetes namespace for the deployment'
         type: string
+      pod_name:
+        description: 'Kubernetes pod name to redeploy after images are built'
+        type: string
         
     secrets:
       GH_TOKEN:
@@ -193,6 +196,6 @@ jobs:
     needs: [setup, build-platform-components]
     uses: IQGeo/devops-engineering-ci-redeploy-eks-pod/.github/workflows/redeploy-eks-pod.yml@main
     with:
-      module: ${{ fromJson(needs.setup.outputs.modules_array)[0] }}
+      pod_name: ${{ inputs.pod_name }}
       namespace: ${{ inputs.namespace }}
     secrets: inherit


### PR DESCRIPTION
Add pod_name input from main module workflow to pass down to redeploy-eks job to redeploy the pod when a new pre-release or stable build occurs for the module.

Successful run here: https://github.com/IQGeo/myworld-product-workflow-manager/actions/runs/18021264864/job/51278897566