### PR TITLE
Add Cairo library for pycairo dependency

### DIFF
--- a/.github/workflows/cut-module.yml
+++ b/.github/workflows/cut-module.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install pip requirements and run cut modules
         run: |
             echo "Install pip requirements and run cut modules"
-            sudo apt-get update && sudo apt install -y libfreetype-dev
+            sudo apt-get update && sudo apt install -y libfreetype-dev libcairo2-dev pkg-config
             pip install -r $CORE_REPO/WebApps/myworldapp/modules/dev_tools/requirements.txt --user
             $CORE_REPO/WebApps/myworldapp/modules/${{ inputs.module}}_${{ inputs.cut_script_directory }}/utils/cut_${{ inputs.module}}_modules $VERSION
             cd temp


### PR DESCRIPTION
Comms had a couple [builds fail today](https://github.com/IQGeo/myworld-product-network-manager-comms/actions/runs/25687276640/job/75414332401) due to pycairo (a transitive dependency) that needs the Cairo C library headers to build from source so I added libcairo2-dev (and pkg-config because it was also recommended) to the apt install line on 111. I'm not sure if this is only needed for comms or if other modules need it so I didn't make it conditional for only comms but lemme know if that's something we should consider instead of doing it for all modules that use this workflow.