### PR TITLE
ET-778: centralized injectors modifications

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -140,23 +140,34 @@ jobs:
       cut_script_directory: ${{ inputs.cut_script_directory }}
     secrets: inherit
 
-  prepare-dockerfile:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout central Dockerfiles repo
-        uses: actions/checkout@v4
-        with:
-          repository: IQGeo/devops-engineering-ci-buildfiles
-          path: central
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Copy module Dockerfile.injector into expected location
-        run: |
-          mkdir -p .github/workflows
-          cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
-      - uses: actions/upload-artifact@v4
-        with:
-          name: injector-dockerfile
-          path: .github/workflows/Dockerfile.injector
+prepare-dockerfile:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Debug GH_TOKEN presence
+      run: |
+        if [ -z "${{ secrets.GH_TOKEN }}" ]; then
+          echo "GH_TOKEN is empty"
+          exit 1
+        else
+          echo "GH_TOKEN is present"
+        fi
+
+    - name: Checkout central Dockerfiles repo
+      uses: actions/checkout@v4
+      with:
+        repository: IQGeo/devops-engineering-ci-buildfiles
+        path: central
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Copy module Dockerfile.injector into expected location
+      run: |
+        mkdir -p .github/workflows
+        cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: injector-dockerfile
+        path: .github/workflows/Dockerfile.injector
     
   build-injectors:
     needs: [setup, cut-artifacts, prepare-dockerfile]

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -152,13 +152,12 @@ jobs:
 
       - name: Copy module Dockerfile.injector into expected location
         run: |
-          mkdir -p .github/workflows
-          cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
+          cp central/Dockerfile.injector.module Dockerfile.injector
 
       - uses: actions/upload-artifact@v4
         with:
           name: injector-dockerfile
-          path: .github/workflows/Dockerfile.injector
+          path: Dockerfile.injector
     
   build-injectors:
     needs: [setup, cut-artifacts, prepare-dockerfile]

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -90,7 +90,7 @@ env:
   ACR_REGISTRY: "iqgeoproddev.azurecr.io"
   
   # External Workflow References
-  MULTI_ARCH_WORKFLOW: "IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main"
+  MULTI_ARCH_WORKFLOW: "IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications"
   EDITIONS_WORKFLOW: "IQGeo/devops-engineering-ci-public-editions-workflow/.github/workflows/build-editions.yml@main"
   
   # Dockerfile Paths  
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         module: ${{ fromJson(needs.setup.outputs.modules_array) }}
-    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
+    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications
     with:
       version: ${{ inputs.version }}
       dockerfile_path: "Dockerfile.injector"

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           repository: IQGeo/devops-engineering-ci-buildfiles
           path: central
+          token: ${{ secrets.GH_TOKEN }}
       - name: Copy module Dockerfile.injector into expected location
         run: |
           mkdir -p .github/workflows

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -140,34 +140,34 @@ jobs:
       cut_script_directory: ${{ inputs.cut_script_directory }}
     secrets: inherit
 
-prepare-dockerfile:
-  runs-on: ubuntu-latest
-  steps:
-    - name: Debug GH_TOKEN presence
-      run: |
-        if [ -z "${{ secrets.GH_TOKEN }}" ]; then
-          echo "GH_TOKEN is empty"
-          exit 1
-        else
-          echo "GH_TOKEN is present"
-        fi
+  prepare-dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug GH_TOKEN presence
+        run: |
+          if [ -z "${{ secrets.GH_TOKEN }}" ]; then
+            echo "GH_TOKEN is empty"
+            exit 1
+          else
+            echo "GH_TOKEN is present"
+          fi
 
-    - name: Checkout central Dockerfiles repo
-      uses: actions/checkout@v4
-      with:
-        repository: IQGeo/devops-engineering-ci-buildfiles
-        path: central
-        token: ${{ secrets.GH_TOKEN }}
+      - name: Checkout central Dockerfiles repo
+        uses: actions/checkout@v4
+        with:
+          repository: IQGeo/devops-engineering-ci-buildfiles
+          path: central
+          token: ${{ secrets.GH_TOKEN }}
 
-    - name: Copy module Dockerfile.injector into expected location
-      run: |
-        mkdir -p .github/workflows
-        cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
+      - name: Copy module Dockerfile.injector into expected location
+        run: |
+          mkdir -p .github/workflows
+          cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: injector-dockerfile
-        path: .github/workflows/Dockerfile.injector
+      - uses: actions/upload-artifact@v4
+        with:
+          name: injector-dockerfile
+          path: .github/workflows/Dockerfile.injector
     
   build-injectors:
     needs: [setup, cut-artifacts, prepare-dockerfile]

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -90,7 +90,7 @@ env:
   ACR_REGISTRY: "iqgeoproddev.azurecr.io"
   
   # External Workflow References
-  MULTI_ARCH_WORKFLOW: "IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications"
+  MULTI_ARCH_WORKFLOW: "IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main"
   EDITIONS_WORKFLOW: "IQGeo/devops-engineering-ci-public-editions-workflow/.github/workflows/build-editions.yml@main"
   
   # Dockerfile Paths  
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         module: ${{ fromJson(needs.setup.outputs.modules_array) }}
-    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications
+    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
       version: ${{ inputs.version }}
       dockerfile_path: "Dockerfile.injector"

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -94,7 +94,7 @@ env:
   EDITIONS_WORKFLOW: "IQGeo/devops-engineering-ci-public-editions-workflow/.github/workflows/build-editions.yml@main"
   
   # Dockerfile Paths  
-  INJECTOR_DOCKERFILE: ".github/workflows/Dockerfile.injector"
+  INJECTOR_DOCKERFILE: "Dockerfile.injector"
   BUILD_DOCKERFILE: "deployment/dockerfile.build"
   APPSERVER_DOCKERFILE: "deployment/dockerfile.appserver"
   TOOLS_DOCKERFILE: "deployment/dockerfile.tools"
@@ -167,7 +167,7 @@ jobs:
     uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
       version: ${{ inputs.version }}
-      dockerfile_path: ".github/workflows/Dockerfile.injector"
+      dockerfile_path: "Dockerfile.injector"
       docker_context: "."
       module: ${{ matrix.module }}
       release_modules: ${{ inputs.release_modules }}

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -78,8 +78,6 @@ on:
         required: true
       REGISTRY_PASSWORD:
         required: true
-      ANTHONY_TOKEN_TEST:
-        required: false
 
 permissions:
   id-token: write
@@ -150,7 +148,7 @@ jobs:
         with:
           repository: IQGeo/devops-engineering-ci-buildfiles
           path: central
-          token: ${{ secrets.ANTHONY_TOKEN_TEST }}
+          token: ${{ secrets.GH_TOKEN }}
       - name: Copy module Dockerfile.injector into expected location
         run: |
           mkdir -p .github/workflows

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Copy module Dockerfile.injector into expected location
         run: |
-          cp central/Dockerfile.injector.module Dockerfile.injector
+          cp central/injectors/module/Dockerfile.injector Dockerfile.injector
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -143,15 +143,6 @@ jobs:
   prepare-dockerfile:
     runs-on: ubuntu-latest
     steps:
-      - name: Debug GH_TOKEN presence
-        run: |
-          if [ -z "${{ secrets.GH_TOKEN }}" ]; then
-            echo "GH_TOKEN is empty"
-            exit 1
-          else
-            echo "GH_TOKEN is present"
-          fi
-
       - name: Checkout central Dockerfiles repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           repository: IQGeo/devops-engineering-ci-buildfiles
           path: central
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.ANTHONY_TOKEN_TEST }}
       - name: Copy module Dockerfile.injector into expected location
         run: |
           mkdir -p .github/workflows

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         module: ${{ fromJson(needs.setup.outputs.modules_array) }}
-    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
+    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications
     with:
       version: ${{ inputs.version }}
       dockerfile_path: "Dockerfile.injector"

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -78,6 +78,8 @@ on:
         required: true
       REGISTRY_PASSWORD:
         required: true
+      ANTHONY_TOKEN_TEST:
+        required: false
 
 permissions:
   id-token: write

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         module: ${{ fromJson(needs.setup.outputs.modules_array) }}
-    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@devops/ET-778-centralized-injectors-modifications
+    uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
       version: ${{ inputs.version }}
       dockerfile_path: "Dockerfile.injector"

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -94,7 +94,7 @@ env:
   EDITIONS_WORKFLOW: "IQGeo/devops-engineering-ci-public-editions-workflow/.github/workflows/build-editions.yml@main"
   
   # Dockerfile Paths  
-  INJECTOR_DOCKERFILE: "Dockerfile.injector"
+  INJECTOR_DOCKERFILE: ".github/workflows/Dockerfile.injector"
   BUILD_DOCKERFILE: "deployment/dockerfile.build"
   APPSERVER_DOCKERFILE: "deployment/dockerfile.appserver"
   TOOLS_DOCKERFILE: "deployment/dockerfile.tools"
@@ -139,16 +139,33 @@ jobs:
       module: ${{ fromJson(needs.setup.outputs.modules_array)[0] }}
       cut_script_directory: ${{ inputs.cut_script_directory }}
     secrets: inherit
+
+  prepare-dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout central Dockerfiles repo
+        uses: actions/checkout@v4
+        with:
+          repository: IQGeo/devops-engineering-ci-buildfiles
+          path: central
+      - name: Copy module Dockerfile.injector into expected location
+        run: |
+          mkdir -p .github/workflows
+          cp central/Dockerfile.injector.module .github/workflows/Dockerfile.injector
+      - uses: actions/upload-artifact@v4
+        with:
+          name: injector-dockerfile
+          path: .github/workflows/Dockerfile.injector
     
   build-injectors:
-    needs: [setup, cut-artifacts]
+    needs: [setup, cut-artifacts, prepare-dockerfile]
     strategy:
       matrix:
         module: ${{ fromJson(needs.setup.outputs.modules_array) }}
     uses: IQGeo/devops-engineering-ci-public-build-multi-arch-workflow/.github/workflows/build-multi-arch.yml@main
     with:
       version: ${{ inputs.version }}
-      dockerfile_path: "Dockerfile.injector"
+      dockerfile_path: ".github/workflows/Dockerfile.injector"
       docker_context: "."
       module: ${{ matrix.module }}
       release_modules: ${{ inputs.release_modules }}


### PR DESCRIPTION
This was one of the missing PRs for the logic. I had the platform logic written, but the module logic was never raised as a PR.

Test of the run is here: https://github.com/IQGeo/devops-engineering-ci-workflow-manager/actions/runs/25764993655

I removed the dockerfile.injector in this branch completely, added the download step to the build push action. Run was successful. 